### PR TITLE
Feature: Attachments in Posts!

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -37,6 +37,12 @@ const nextConfig = {
         hostname: "utfs.io",
         pathname: `/a/${process.env.NEXT_PUBLIC_UPLOADTHING_APP_ID}/*`,
       },
+      // Post attachments of uploadthing domain -> src/app/api/uploadthing/core.ts
+      {
+        protocol: "https",
+        hostname: "utfs.io",
+        pathname: `/f/*`,
+      },
     ],
   },
 };

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,7 +25,7 @@ model User {
   avatarUrl    String?
   bio          String?
   sessions     Session[]
-  posts         Post[]
+  posts        Post[]
 
   /// `following` represents the list of users this user is following.
   /// Using `@relation("Followers")` indicates that this user is the follower
@@ -87,18 +87,52 @@ model Follow {
   /// can only follow a specific user once, preventing duplicate follow records.
   /// Also ensures that we have the same combination of followerId and followingId.
   @@unique([followerId, followingId])
-  
   /// `@@map("follows")` renames the underlying table in the database to "follows".
   /// This makes it clearer in the database that this table stores follow relationships.
   @@map("follows")
 }
 
 model Post {
-  id        String   @id @default(cuid())
-  content   String
-  userId    String
-  user      User     @relation(references: [id], fields: [userId], onDelete: Cascade)
-  createdAt DateTime @default(now())
+  id          String       @id @default(cuid())
+  content     String
+  userId      String
+  user        User         @relation(references: [id], fields: [userId], onDelete: Cascade)
+  createdAt   DateTime     @default(now())
+  attachments Attachment[]
 
   @@map("posts")
+}
+
+// A single post can have multiple attachments, hence bloating our Post model is not a good idea.
+// Instead, we create a separate model for attachments and establish a one-to-many relation between Post and Attachment.
+model Attachment {
+  id String @id @default(cuid())
+
+  // Since the media can be very large (especially videos), it might take a while for the upload to finish.
+  // So, we would need to upload them immediately before the user submits the post (by clicking the "Post" button).
+  // Because, when we upload after clicking the "Post" button, the user would have to wait for the 
+  // upload to finish which would take a while. 
+  //
+  // But here's the catch: If the user decides to cancel the post, we would have already uploaded the media.
+  // In such cases, we won't have a post to associate the media with. For this reason, the postId is optional.
+  // And if the user decides to post the media, we would associate the media with the post.
+  // 
+  // Don't worry about the uploaded media being orphaned. We can run a cron job to delete media that 
+  // are not associated with any post later. This way we are not bloating our database with orphaned media.
+  postId String?
+
+  // On delete of an attachment, we don't want to delete the post. So, we set the onDelete to SetNull, so that the
+  // postId of the attachment is set to null when the post is deleted.
+  post Post? @relation(fields: [postId], references: [id], onDelete: SetNull)
+
+  type      MediaType
+  url       String
+  createdAt DateTime  @default(now())
+
+  @@map("post_attachments")
+}
+
+enum MediaType {
+  IMAGE
+  VIDEO
 }

--- a/src/components/posts/Post.tsx
+++ b/src/components/posts/Post.tsx
@@ -30,11 +30,14 @@
 import { PostData } from "@/lib/types";
 import Link from "next/link";
 import UserAvatar from "../UserAvatar";
-import { formatRelativeDate, getSanitizedDisplayName } from "@/lib/utils";
+import { cn, formatRelativeDate, getSanitizedDisplayName } from "@/lib/utils";
 import { useSession } from "@/app/(main)/SessionProvider";
 import PostActionsMenu from "./PostActionsMenu";
 import Linkify from "../Linkify";
 import UserTooltip from "../UserTooltip";
+import { Attachment } from "@prisma/client";
+import Image from "next/image";
+import React from "react";
 
 interface PostConfig {
   post: PostData;
@@ -104,6 +107,56 @@ export default function Post({ post }: PostConfig) {
       <Linkify>
         <div className="whitespace-pre-line break-words">{post.content}</div>
       </Linkify>
+
+      {!!post.attachments.length && (
+        <MediaPreview attachments={post.attachments} />
+      )}
     </article>
+  );
+}
+
+interface MediaPreviewConfig {
+  // prisma schema type for Attachment
+  attachments: Attachment[];
+}
+
+function MediaPreview({ attachments }: MediaPreviewConfig) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-3",
+        attachments.length > 1 && "sm:grid sm:grid-cols-2"
+      )}
+    >
+      {React.Children.toArray(
+        attachments.map((attachment) => {
+          if (attachment.type === "IMAGE") {
+            return (
+              <Image
+                src={attachment.url}
+                alt="Attachment"
+                width={500}
+                height={500}
+                className="mx-auto size-fit max-h-[30rem] rounded-2xl"
+              />
+            );
+          }
+
+          if (attachment.type === "VIDEO") {
+            return (
+              <div>
+                <video
+                  src={attachment.url}
+                  controls
+                  className="mx-auto size-fit max-h-[30rem] rounded-2xl"
+                />
+              </div>
+            );
+          }
+
+          return <p className="text-destructive">Unsupported media type</p>;
+        })
+      )}
+    </div>
   );
 }

--- a/src/components/posts/editor/Attachments/Handler.tsx
+++ b/src/components/posts/editor/Attachments/Handler.tsx
@@ -1,0 +1,47 @@
+import { Button } from "@/components/ui/button";
+import { ImageIcon } from "lucide-react";
+import { useRef } from "react";
+
+interface AttachmentHandlerConfig {
+  onFilesSelected: (files: Array<File>) => void;
+  disabled: boolean;
+}
+
+function AttachmentHandler({
+  onFilesSelected,
+  disabled,
+}: AttachmentHandlerConfig) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  return (
+    <>
+      <Button
+        variant={"ghost"}
+        size={"icon"} // because we are using only an icon here
+        className="hover:text-primary text-primary"
+        disabled={disabled}
+        onClick={() => fileInputRef.current?.click()}
+      >
+        <ImageIcon size={20} />
+      </Button>
+
+      <input
+        type="file"
+        ref={fileInputRef}
+        // sr-only -> screen reader only
+        className="hidden sr-only"
+        multiple
+        accept="image/* video/*"
+        onChange={(e) => {
+          const files = Array.from(e.target.files || []);
+          if (files.length) {
+            onFilesSelected(files);
+            e.target.value = ""; // Reset the input value to allow selecting the same file again
+          }
+        }}
+      />
+    </>
+  );
+}
+
+export default AttachmentHandler;

--- a/src/components/posts/editor/Attachments/Previews.tsx
+++ b/src/components/posts/editor/Attachments/Previews.tsx
@@ -1,7 +1,7 @@
 import { cn } from "@/lib/utils";
 import { Attachment } from "../useMediaUploads";
 import Image from "next/image";
-import { ImageIcon } from "lucide-react";
+import { ImageIcon, X } from "lucide-react";
 
 interface AttachmentPreviewConfig {
   attachments: Attachment[];
@@ -59,7 +59,7 @@ function Preview({
           className="absolute top-3 right-3 rounded-full bg-foreground p-1.5 text-background transition-colors hover:bg-foreground/60"
           onClick={onRemove}
         >
-          <ImageIcon size={20} />
+          <X size={20} />
         </button>
       )}
     </div>

--- a/src/components/posts/editor/Attachments/Previews.tsx
+++ b/src/components/posts/editor/Attachments/Previews.tsx
@@ -1,0 +1,69 @@
+import { cn } from "@/lib/utils";
+import { Attachment } from "../useMediaUploads";
+import Image from "next/image";
+import { ImageIcon } from "lucide-react";
+
+interface AttachmentPreviewConfig {
+  attachments: Attachment[];
+  removeAttachment: (fileName: string) => void;
+}
+
+function AttachmentPreview({
+  attachments,
+  removeAttachment,
+}: AttachmentPreviewConfig) {
+  return (
+    <div className={cn("", attachments.length > 1 && "sm:grid sm:grid-cols-2")}>
+      {attachments.map((attachment) => (
+        <Preview
+          key={attachment.file.name}
+          attachment={attachment}
+          onRemove={() => removeAttachment(attachment.file.name)}
+        />
+      ))}
+    </div>
+  );
+}
+
+interface PreviewConfig {
+  attachment: Attachment;
+  onRemove: () => void;
+}
+
+function Preview({
+  attachment: { file, isUploading },
+  onRemove,
+}: PreviewConfig) {
+  const previewURL = URL.createObjectURL(file);
+
+  return (
+    <div
+      className={cn("relative mx-auto size-fit", isUploading && "opacity-50")}
+    >
+      {file.type.startsWith("image/") ? (
+        <Image
+          src={previewURL}
+          alt="Attachment Preview"
+          width={500}
+          height={500}
+          className="size-fit max-h-[30rem] rounded-2xl"
+        />
+      ) : (
+        <video controls className="size-fit max-h-[30rem] rounded-2xl">
+          <source src={previewURL} type={file.type} />
+        </video>
+      )}
+
+      {!isUploading && (
+        <button
+          className="absolute top-3 right-3 rounded-full bg-foreground p-1.5 text-background transition-colors hover:bg-foreground/60"
+          onClick={onRemove}
+        >
+          <ImageIcon size={20} />
+        </button>
+      )}
+    </div>
+  );
+}
+
+export default AttachmentPreview;

--- a/src/components/posts/editor/actions.ts
+++ b/src/components/posts/editor/actions.ts
@@ -5,18 +5,30 @@ import prisma from "@/lib/prisma";
 import { getPostDataSelect } from "@/lib/types";
 import { createPostSchema } from "@/lib/validations";
 
-export async function createPost({ content }: { content: string }) {
+export async function createPost(input: {
+  content: string;
+  mediaIds: string[];
+}) {
   const { user } = await validateRequest();
 
   //   If user is not authenticated, throw Unauthorized error
   if (!user) throw new Error("Unauthorized");
 
-  const {} = createPostSchema.parse({ content });
+  const { content, mediaIds } = createPostSchema.parse(input);
 
   const newPost = await prisma.post.create({
     data: {
       content,
       userId: user.id,
+      attachments: {
+        /**
+         * Connects the mediaIds to the post.
+         * ! READ:
+         * ! https://www.prisma.io/docs/orm/reference/prisma-client-reference#connect
+         * ! https://www.prisma.io/docs/orm/prisma-client/queries/relation-queries#connect-multiple-records
+         */
+        connect: mediaIds.map((id) => ({ id })),
+      },
     },
     include: getPostDataSelect(user.id),
   });

--- a/src/components/posts/editor/useMediaUploads.ts
+++ b/src/components/posts/editor/useMediaUploads.ts
@@ -1,0 +1,167 @@
+/**
+ * Custom hook for handling the media uploads against a post. This hook is used in the
+ * PostEditor component to upload the media files (images, videos, etc.) to the server.
+ *
+ * Has all the necessary functions to upload the media files, remove the uploaded files,
+ * and reset the state once the upload is complete.
+ */
+
+import { toast } from "@/hooks/use-toast";
+import { useUploadThing } from "@/lib/uploadthing";
+import { useState } from "react";
+
+export interface Attachment {
+  file: File;
+  mediaId?: string; // Since we get the mediaId only after the upload is complete!
+  isUploading: boolean;
+}
+
+export default function useMediaUploads() {
+  const [attachments, setAttachments] = useState<Attachment[]>([]);
+  const [uploadProgress, setUploadProgress] = useState<number>();
+
+  const { startUpload, isUploading } = useUploadThing(
+    "postAttachmentUploader",
+    {
+      // Overriding the uploadthing function
+      onBeforeUploadBegin: (files) => {
+        /**
+         * Triggered before the upload begins. This is a good place to prepare the state.
+         *
+         * We need to:
+         * 1. Rename the files
+         *      Why?
+         *      Once the upload is done and we get the mediaId, it would be easier to identify
+         *      the corresponding attachment again, because the file doesn't have a uniqueId now.
+         *      So, we can create a unique name instead to recognize the corresponding attachment.
+         * 2. Set them to attachments state
+         */
+
+        const renamedFiles = files.map((file) => {
+          const extension = file.name.split(".").pop();
+          return new File(
+            [file],
+            `attachment_${crypto.randomUUID()}.${extension}`,
+            {
+              type: file.type,
+            }
+          );
+        });
+
+        setAttachments((prevAttachments) => [
+          ...prevAttachments,
+          ...renamedFiles.map((file) => ({
+            file,
+            isUploading: true,
+          })),
+        ]);
+
+        return renamedFiles;
+      },
+      onUploadProgress: setUploadProgress,
+      onClientUploadComplete: (response) => {
+        /**
+         * Hover over the response to check the structure of the response. This would be whatever
+         * we have setup in the uploadthing file router.
+         *
+         * Now that the upload is complete, we need to update the attachments state with the
+         * mediaId for the corresponding attachment. This is where the renamed file name comes in
+         * handy. We already have this in the attachments state. So we just need to filter it out
+         * against the response.
+         */
+        setAttachments((prevAttachments) => {
+          return prevAttachments.map((attachment) => {
+            const uploadedFile = response.find(
+              (file) => file.name === attachment.file.name
+            );
+
+            if (!uploadedFile) return attachment;
+
+            return {
+              ...attachment,
+              mediaId: uploadedFile.serverData.mediaId,
+              isUploading: false,
+            };
+          });
+        });
+      },
+      onUploadError: (error) => {
+        /**
+         * When an upload fails, we would need to remove the corresponding attachment from the
+         * attachments state. This is because the upload has failed and we don't have the mediaId
+         * for this attachment. So, we can't use it in the post.
+         *
+         * But how do we know which attachment has failed? This is where the isUploading flag comes
+         * in handy. We can filter out the attachments that are still uploading and remove them, because
+         * the ones that are not uploading are already uploaded successfully.
+         */
+        setAttachments((prevAttachments) =>
+          prevAttachments.filter((attachment) => attachment.isUploading)
+        );
+
+        toast({
+          variant: "destructive",
+          description: error.message,
+        });
+      },
+    }
+  );
+
+  /**
+   * The upload progress might misbehave if we allow multiple uploads at the same time. So, we
+   * need to make sure that we are allowing only one upload at a time. This means that if there
+   * are 3 files to upload against a post, we wait until all the 3 files are uploaded, before we
+   * allow the user to upload more files. The following function takes care of this.
+   *
+   * Along with this, we also need to make sure that the user is not trying to upload more than
+   * 5 attachments at a time. This is because we have a limit of 5 attachments per post. If you
+   * need to change this in the future, make sure you update the backend (file router) as well.
+   */
+  function handleStartUpload(files: Array<File>) {
+    if (isUploading) {
+      toast({
+        variant: "destructive",
+        description: "Please wait until the current upload is complete",
+      });
+      return;
+    }
+
+    if (attachments.length + files.length > 5) {
+      toast({
+        variant: "destructive",
+        description: "You can only upload 5 attachments at a time",
+      });
+      return;
+    }
+
+    startUpload(files);
+  }
+
+  /**
+   * We would also need the ability to remove an attachment from the attachments state. This is
+   * because the user might want to remove an attachment that they have uploaded by mistake.
+   */
+  function removeAttachment(fileName: string) {
+    setAttachments((prevAttachments) =>
+      prevAttachments.filter((attachment) => attachment.file.name !== fileName)
+    );
+  }
+
+  /**
+   * Once the upload is complete, we need to reset the attachments state. This is because we
+   * don't want to show the uploaded attachments in the editor anymore.
+   */
+  function reset() {
+    setAttachments([]);
+    setUploadProgress(undefined);
+  }
+
+  return {
+    startUpload: handleStartUpload,
+    attachments,
+    isUploading,
+    uploadProgress,
+    removeAttachment,
+    reset,
+  };
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -34,6 +34,7 @@ export function getPostDataSelect(loggedInUserId: string) {
     user: {
       select: getUserDataSelect(loggedInUserId),
     },
+    attachments: true,
   } satisfies Prisma.PostSelect; // Explore more on "satisfies" keyword in TypeScript -- https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-9.html#the-satisfies-operator
 }
 

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -22,6 +22,9 @@ export type LoginConfig = z.infer<typeof loginSchema>;
 // Posts ---> START
 export const createPostSchema = z.object({
   content: requiredString,
+  mediaIds: z
+    .array(z.string())
+    .max(5, "You can upload at most 5 pissing files"),
 });
 // Posts ---> END
 


### PR DESCRIPTION
 - Added a new file router for handling the post media uploads.
 - Updated the schema to store attachments. Made a 1 to many relationship between Post and attachments.
 - Updated the server actions to connect the attachments to a post when it is being submitted.
 - Updated the validations for post creation.
 - Added a custom hook with necessary config to handle the media attachments in the Post Editor.
 - Used shadcn and tailwind CSS to fuel the UI components.
 - Displaying the attachments for a Post.
 - Updating the next.config.ts to include the post attachments domain.