### PR TITLE
Tweak: Changing the prev and next button icons in the carousel.

### DIFF
--- a/src/components/MediaCarousel.tsx
+++ b/src/components/MediaCarousel.tsx
@@ -15,7 +15,7 @@ import "slick-carousel/slick/slick-theme.css";
 import { Attachment } from "@prisma/client";
 import Image from "next/image";
 import React from "react";
-import { SquareArrowLeft, SquareArrowRight } from "lucide-react";
+import { ArrowLeft, ArrowRight } from "lucide-react";
 
 export const getAttachmentToRender = (attachment: Attachment) => {
   if (attachment.type === "IMAGE") {
@@ -68,7 +68,7 @@ export default function MediaCarousel({
         className="cursor-pointer absolute top-1/2 left-0 p-2 bg-primary rounded-full z-10 hover:opacity-80"
         onClick={() => sliderRef?.current?.slickPrev()}
       >
-        <SquareArrowLeft className="text-white size-4" />
+        <ArrowLeft className="text-white size-4" />
       </div>
       {attachments.length > 1 ? (
         <Slider {...carouselSettings} className="w-full" ref={sliderRef}>
@@ -85,7 +85,7 @@ export default function MediaCarousel({
         className="cursor-pointer absolute top-1/2 right-0 p-2 bg-primary rounded-full z-10 hover:opacity-80"
         onClick={() => sliderRef?.current?.slickNext()}
       >
-        <SquareArrowRight className="text-white size-4" />
+        <ArrowRight className="text-white size-4" />
       </div>
     </div>
   );


### PR DESCRIPTION
Old Icons:
<img width="75" alt="Screenshot 2024-11-02 at 13 14 50" src="https://github.com/user-attachments/assets/3ab5365a-104e-44cf-992d-d48f92c6b98f">
<img width="75" alt="Screenshot 2024-11-02 at 13 14 44" src="https://github.com/user-attachments/assets/cb415499-6df3-4dc6-8ea5-26b588d2c267">

Updated Icons:
<img width="75" alt="Screenshot 2024-11-02 at 13 14 31" src="https://github.com/user-attachments/assets/472947df-8de5-48e9-8c28-bf8d335f2b29">
<img width="81" alt="Screenshot 2024-11-02 at 13 14 27" src="https://github.com/user-attachments/assets/8758fc76-6769-4848-acb5-3500c19df391">

